### PR TITLE
添加OPC UA读写节点

### DIFF
--- a/endpoint/opcua/opcua.go
+++ b/endpoint/opcua/opcua.go
@@ -1,4 +1,4 @@
-package opc_ua
+package opcua
 
 import (
 	"context"

--- a/endpoint/opcua/opcua.go
+++ b/endpoint/opcua/opcua.go
@@ -162,6 +162,7 @@ func (r *ResponseMessage) GetError() error {
 	return r.err
 }
 
+// OpcUaConfig OPC UA Server配置
 type OpcUaConfig struct {
 	//OPC UA Server Endpoint, eg. opc.tcp://localhost:4840
 	Server string
@@ -212,11 +213,15 @@ type OpcUa struct {
 	impl.BaseEndpoint
 	base.SharedNode[*opcua.Client]
 	RuleConfig types.Config
-	Config     OpcUaConfig
-	Router     endpointApi.Router
-	client     *opcua.Client
-	cronTask   *cron.Cron
-	taskId     cron.EntryID
+	// opcua client相关配置
+	Config OpcUaConfig
+	Router endpointApi.Router
+	// opcua client实例
+	client *opcua.Client
+	// 定时任务实例
+	cronTask *cron.Cron
+	// 定时任务id
+	taskId cron.EntryID
 }
 
 // Type 组件类型
@@ -224,6 +229,7 @@ func (x *OpcUa) Type() string {
 	return Type
 }
 
+// New 创建组件实例
 func (x *OpcUa) New() types.Node {
 	return &OpcUa{
 		Config: OpcUaConfig{

--- a/external/opcua/opcua_read.go
+++ b/external/opcua/opcua_read.go
@@ -83,7 +83,7 @@ func (x *ReadNode) New() types.Node {
 
 // Type 返回组件类型
 func (x *ReadNode) Type() string {
-	return "x/opcUaRead"
+	return "x/opcuaRead"
 }
 
 func (x *ReadNode) Init(ruleConfig types.Config, configuration types.Configuration) error {
@@ -108,7 +108,7 @@ func (x *ReadNode) OnMsg(ctx types.RuleContext, msg types.RuleMsg) {
 		return
 	}
 	nodeIds := make([]string, 0)
-	err = json.Unmarshal([]byte(msg.Metadata.GetValue("nodeIds")), &nodeIds)
+	err = json.Unmarshal([]byte(msg.Data), &nodeIds)
 	if err != nil {
 		ctx.TellFailure(msg, err)
 		return

--- a/external/opcua/opcua_read_test.go
+++ b/external/opcua/opcua_read_test.go
@@ -13,7 +13,7 @@ import (
 func TestReadNode(t *testing.T) {
 	Registry := &types.SafeComponentSlice{}
 	Registry.Add(&ReadNode{})
-	var nodeType = "x/opcUaRead"
+	var nodeType = "x/opcuaRead"
 
 	// t.Run("NewNode", func(t *testing.T) {
 	// 	test.NodeNew(t, nodeType, &ReadNode{}, types.Configuration{
@@ -28,14 +28,15 @@ func TestReadNode(t *testing.T) {
 	nodeIds = append(nodeIds, "ns=3;i=1009")
 	d, _ := json.Marshal(nodeIds)
 
-	meta := types.BuildMetadata(make(map[string]string))
-	meta.PutValue("nodeIds", string(d))
+	// meta := types.BuildMetadata(make(map[string]string))
+	// meta.PutValue("nodeIds", string(d))
 
 	msgList := []test.Msg{
 		{
-			MetaData: meta,
+			MetaData: nil,
 			DataType: types.JSON,
 			MsgType:  opcuaClient.OPC_UA_DATA_MSG_TYPE,
+			Data:     string(d),
 		},
 	}
 

--- a/external/opcua/opcua_read_test.go
+++ b/external/opcua/opcua_read_test.go
@@ -24,8 +24,8 @@ func TestReadNode(t *testing.T) {
 	// 	}, Registry)
 	// })
 	nodeIds := make([]string, 0)
-	nodeIds = append(nodeIds, "ns=3;i=1001")
-	nodeIds = append(nodeIds, "ns=3;i=1009")
+	nodeIds = append(nodeIds, "ns=3;i=1101")
+	nodeIds = append(nodeIds, "ns=3;i=1109")
 	d, _ := json.Marshal(nodeIds)
 
 	// meta := types.BuildMetadata(make(map[string]string))

--- a/external/opcua/opcua_write.go
+++ b/external/opcua/opcua_write.go
@@ -83,7 +83,7 @@ func (x *WriteNode) New() types.Node {
 
 // Type 返回组件类型
 func (x *WriteNode) Type() string {
-	return "x/opcUaWrite"
+	return "x/opcuaWrite"
 }
 
 func (x *WriteNode) Init(ruleConfig types.Config, configuration types.Configuration) error {

--- a/external/opcua/opcua_write_test.go
+++ b/external/opcua/opcua_write_test.go
@@ -12,7 +12,7 @@ import (
 func TestWriteNode(t *testing.T) {
 	Registry := &types.SafeComponentSlice{}
 	Registry.Add(&WriteNode{})
-	var writeNodeType = "x/opcUaWrite"
+	var writeNodeType = "x/opcuaWrite"
 
 	t.Run("NewNode", func(t *testing.T) {
 		test.NodeNew(t, writeNodeType, &WriteNode{}, types.Configuration{

--- a/pkg/opcua_client/opcua_client.go
+++ b/pkg/opcua_client/opcua_client.go
@@ -19,6 +19,7 @@ const OPC_UA_DATA_MSG_TYPE = "OPC_UA_DATA"
 
 var logger = types.DefaultLogger()
 
+// Data OPC数据封装结构体
 type Data struct {
 	DisplayName string      `json:"displayName"`
 	NodeId      string      `json:"nodeId"`
@@ -30,6 +31,7 @@ type Data struct {
 	Timestamp   time.Time   `json:"timestamp"`
 }
 
+// ParseValue 解析数据FloatValue
 func (d *Data) ParseValue() (*Data, error) {
 	var err error
 	if d != nil && d.Value != nil {
@@ -78,27 +80,42 @@ func (d *Data) ParseValue() (*Data, error) {
 	return d, nil
 }
 
+// ConfigProp 统一OPCUA客户端初始化参数接口
 type ConfigProp interface {
+	// GetServer 获取OPCUA服务地址
 	GetServer() string
+	// GetPolicy 获取OPCUA安全策略
 	GetPolicy() string
+	// GetMode 获取OPCUA安全模式
 	GetMode() string
+	// GetAuth 获取OPCUA认证方式
 	GetAuth() string
+	// GetUsername 获取OPCUA认证用户名
 	GetUsername() string
+	// GetPassword 获取OPCUA认证密码
 	GetPassword() string
+	// GetCertFile 获取OPCUA证书文件
 	GetCertFile() string
+	// GetCertKeyFile 获取OPCUA证书私钥文件
 	GetCertKeyFile() string
 }
 
+// OpcUaClientHolder OPCUA客户端相关配置
 type OpcUaClientHolder struct {
+	// Config OPC客户端配置
 	Config ConfigProp
-	Ctx    context.Context
+	// Ctx 上下文
+	Ctx context.Context
+	// Logger 日志
 	Logger types.Logger
 }
 
+// Printf 日志输出
 func (x *OpcUaClientHolder) Printf(format string, v ...interface{}) {
 	x.Logger.Printf(format, v...)
 }
 
+// DefaultHolder 默认配置
 func DefaultHolder(c ConfigProp) *OpcUaClientHolder {
 	return &OpcUaClientHolder{
 		Config: c,
@@ -107,6 +124,7 @@ func DefaultHolder(c ConfigProp) *OpcUaClientHolder {
 	}
 }
 
+// NewOpcUaClient 创建OPCUA客户端
 func (x *OpcUaClientHolder) NewOpcUaClient() (*opcua.Client, error) {
 	// Get a list of the endpoints for our target server
 	endpoints, err := opcua.GetEndpoints(x.Ctx, x.Config.GetServer())
@@ -129,6 +147,7 @@ func (x *OpcUaClientHolder) NewOpcUaClient() (*opcua.Client, error) {
 	return c, nil
 }
 
+// createOptions 构建Options
 func (x *OpcUaClientHolder) createOptions(endpoints []*ua.EndpointDescription) []opcua.Option {
 
 	opts := []opcua.Option{}
@@ -317,6 +336,7 @@ func (x *OpcUaClientHolder) printEndpointOptions(endpoints []*ua.EndpointDescrip
 	}
 }
 
+// Read 读取点位数据
 func Read(client *opcua.Client, nodeIds []string) ([]Data, *ua.ReadResponse, error) {
 	ctx := context.Background()
 	allIds := make([]*ua.ReadValueID, 0)


### PR DESCRIPTION
- 添加OPC UA读写节点

OPC UA配置：

> //OPC UA Server Endpoint, eg. opc.tcp://localhost:4840
> 	Server string
> 	//Security Policy URL or one of None, Basic128Rsa15, Basic256, Basic256Sha256
> 	Policy string
> 	//Security Mode: one of None, Sign, SignAndEncrypt
> 	Mode string
> 	//Authentication Mode: one of Anonymous, UserName, Certificate
> 	Auth     string
> 	Username string
> 	Password string
> 	//OPC UA Server CertFile Path
> 	CertFile string
> 	//OPC UA Server CertKeyFile Path
> 	CertKeyFile string


读节点：
需要在Msg中配置读取点位列表 ，以下配置代码供参考

> var ids =["ns=3;i=1003","ns=3;i=1005"]
> msg=JSON.stringify(ids)
> 

写节点：
通过Msg中获取需要写入的点位信息，以下配置代码供参考

> var data = [{nodeId:"ns=3;i=1009",value:9.29},{nodeId:"ns=3;i=1001",value:3.59}]
> msg = JSON.stringify(data);
