### PR TITLE
feat:add modbus node

### DIFF
--- a/external/modbus/modbus.go
+++ b/external/modbus/modbus.go
@@ -56,6 +56,8 @@ type ModbusConfiguration struct {
 	Server string
 	// Modbus 方法名称
 	Cmd string
+	// UnitId unit/slave id to use
+	UnitId uint8
 	// address 寄存器地址:允许使用 ${} 占位符变量
 	Address string
 	// quantity 寄存器数量:允许使用 ${} 占位符变量
@@ -64,15 +66,30 @@ type ModbusConfiguration struct {
 	Value string
 	// RegType 寄存器类型：  允许使用 ${} 占位符变量
 	RegType string
-	// UnitId unit/slave id to use
-	UnitId uint8
-	// Timeout sets the request timeout value,单位秒
-	Timeout int64
+	TcpConfig
+	RtuConfig
+	EncodingConfig
+}
+
+type EncodingConfig struct {
 	// Endianness register endianness <little|big>
 	Endianness modbus.Endianness
 	// WordOrder word ordering for 32-bit registers <highfirst|hf|lowfirst|lf>
 	WordOrder modbus.WordOrder
+}
 
+type TcpConfig struct {
+	// Timeout sets the request timeout value,单位秒
+	Timeout int64
+	// CertPath
+	CertPath string
+	// KeyPath
+	KeyPath string
+	// CaPath
+	CaPath string
+}
+
+type RtuConfig struct {
 	// Speed sets the serial link speed (in bps, rtu only)
 	Speed uint
 	// DataBits sets the number of bits per serial character (rtu only)
@@ -81,13 +98,6 @@ type ModbusConfiguration struct {
 	Parity uint
 	// StopBits sets the number of serial stop bits (rtu only)
 	StopBits uint
-
-	// CertPath
-	CertPath string
-	// KeyPath
-	KeyPath string
-	// CaPath
-	CaPath string
 }
 
 // ModbusNode 客户端节点，
@@ -129,16 +139,22 @@ func (x *ModbusNode) Type() string {
 func (x *ModbusNode) New() types.Node {
 	return &ModbusNode{
 		Config: ModbusConfiguration{
-			Server:     DefaultServer,
-			Cmd:        "ReadCoils",
-			Timeout:    5,
-			UnitId:     DefaultUnitId,
-			Endianness: DefaultEndianness,
-			WordOrder:  DefaultWordOrder,
-			Speed:      DefaultSpeed,
-			DataBits:   DefaultDataBits,
-			Parity:     DefaultParity,
-			StopBits:   2,
+			Server: DefaultServer,
+			Cmd:    "ReadCoils",
+			UnitId: DefaultUnitId,
+			TcpConfig: TcpConfig{
+				Timeout: 5,
+			},
+			EncodingConfig: EncodingConfig{
+				Endianness: DefaultEndianness,
+				WordOrder:  DefaultWordOrder,
+			},
+			RtuConfig: RtuConfig{
+				Speed:    DefaultSpeed,
+				DataBits: DefaultDataBits,
+				Parity:   DefaultParity,
+				StopBits: 2,
+			},
 		},
 	}
 }

--- a/external/modbus/modbus.go
+++ b/external/modbus/modbus.go
@@ -1,0 +1,473 @@
+/*
+ * Copyright 2025 The RuleGo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package modbus
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rulego/rulego"
+	"github.com/rulego/rulego/api/types"
+	"github.com/rulego/rulego/components/base"
+	"github.com/rulego/rulego/utils/maps"
+	"github.com/rulego/rulego/utils/str"
+	"github.com/simonvetter/modbus"
+)
+
+const (
+	DefaultServer                       = "tcp://127.0.0.1:502"
+	DefaultSpeed      uint              = 19200
+	DefaultDataBits   uint              = 8
+	DefaultParity     uint              = modbus.PARITY_NONE
+	DefaultStopBits   uint              = 2
+	DefaultTimeout    time.Duration     = time.Second * 5
+	DefaultEndianness modbus.Endianness = modbus.BIG_ENDIAN
+	DefaultWordOrder  modbus.WordOrder  = modbus.HIGH_WORD_FIRST
+	DefaultUnitId     uint8             = 1
+)
+
+// 注册节点
+func init() {
+	_ = rulego.Registry.Register(&ModbusNode{})
+}
+
+// ModbusConfiguration 节点配置
+type ModbusConfiguration struct {
+	// 服务器地址
+	Server string
+	// Modbus 方法名称
+	Cmd string
+	// address 寄存器地址:允许使用 ${} 占位符变量
+	Address string
+	// quantity 寄存器数量:允许使用 ${} 占位符变量
+	Quantity string
+	// value 寄存器值:  允许使用 ${} 占位符变量
+	Value string
+	// RegType 寄存器类型：  允许使用 ${} 占位符变量
+	RegType string
+	// UnitId unit/slave id to use
+	UnitId uint8
+	// Timeout sets the request timeout value,单位秒
+	Timeout int64
+	// Endianness register endianness <little|big>
+	Endianness modbus.Endianness
+	// WordOrder word ordering for 32-bit registers <highfirst|hf|lowfirst|lf>
+	WordOrder modbus.WordOrder
+
+	// Speed sets the serial link speed (in bps, rtu only)
+	Speed uint
+	// DataBits sets the number of bits per serial character (rtu only)
+	DataBits uint
+	// Parity sets the serial link parity mode (rtu only)
+	Parity uint
+	// StopBits sets the number of serial stop bits (rtu only)
+	StopBits uint
+
+	// CertPath
+	CertPath string
+	// KeyPath
+	KeyPath string
+	// CaPath
+	CaPath string
+}
+
+// ModbusNode 客户端节点，
+// 成功：转向Success链，发送消息执行结果存放在msg.Data
+// 失败：转向Failure链
+type ModbusNode struct {
+	base.SharedNode[*modbus.ModbusClient]
+	//节点配置
+	Config            ModbusConfiguration
+	conn              *modbus.ModbusClient
+	addressTemplate   str.Template
+	quanitityTemplate str.Template
+	valueTemplate     str.Template
+	regTypeTemplate   str.Template
+}
+
+type Params struct {
+	Cmd      string         `json:"cmd" `
+	Address  uint16         `json:"address" `
+	Quantity uint16         `json:"quantity" `
+	Value    []byte         `json:"-" `
+	Val      string         `json:"value" `
+	RegType  modbus.RegType `json:"regType" `
+}
+
+type ModbusData struct {
+	Params *Params `json:"params" `
+	Data   any     `json:"data" `
+}
+
+// Type 返回组件类型
+func (x *ModbusNode) Type() string {
+	return "x/modbus"
+}
+
+// New 默认参数
+func (x *ModbusNode) New() types.Node {
+	return &ModbusNode{
+		Config: ModbusConfiguration{
+			Server:     DefaultServer,
+			Cmd:        "ReadCoils",
+			Timeout:    5,
+			UnitId:     DefaultUnitId,
+			Endianness: DefaultEndianness,
+			WordOrder:  DefaultWordOrder,
+			Speed:      DefaultSpeed,
+			DataBits:   DefaultDataBits,
+			Parity:     DefaultParity,
+			StopBits:   2,
+		},
+	}
+}
+
+// Init 初始化组件
+func (x *ModbusNode) Init(ruleConfig types.Config, configuration types.Configuration) error {
+	err := maps.Map2Struct(configuration, &x.Config)
+	if err == nil {
+		//初始化客户端
+		err = x.SharedNode.Init(ruleConfig, x.Type(), x.Config.Server, true, func() (*modbus.ModbusClient, error) {
+			return x.initClient()
+		})
+	}
+	//初始化模板
+	x.addressTemplate = str.NewTemplate(x.Config.Address)
+	x.quanitityTemplate = str.NewTemplate(x.Config.Quantity)
+	x.valueTemplate = str.NewTemplate(x.Config.Value)
+	x.regTypeTemplate = str.NewTemplate(x.Config.RegType)
+	return err
+}
+
+// OnMsg 处理消息
+func (x *ModbusNode) OnMsg(ctx types.RuleContext, msg types.RuleMsg) {
+	// x.Locker.Lock()
+	// defer x.Locker.Unlock()
+	var (
+		err      error
+		data     any
+		params   *Params
+		boolVals []bool
+		boolVal  bool
+		ui16     uint16
+		ui32     uint32
+		ui64     uint64
+		f32      float32
+		f64      float64
+		ui16s    []uint16
+		ui32s    []uint32
+		ui64s    []uint64
+		f32s     []float32
+		f64s     []float64
+		result   ModbusData = ModbusData{}
+	)
+	x.conn, err = x.SharedNode.Get()
+	if err != nil {
+		ctx.TellFailure(msg, err)
+		return
+	}
+	params, err = x.getParams(ctx, msg)
+	if err != nil {
+		ctx.TellFailure(msg, err)
+		return
+	}
+	result.Params = params
+
+	switch x.Config.Cmd {
+	case "ReadCoils":
+		data, err = x.conn.ReadCoils(params.Address, params.Quantity)
+	case "ReadCoil":
+		data, err = x.conn.ReadCoil(params.Address)
+	case "ReadDiscreteInputs":
+		data, err = x.conn.ReadDiscreteInputs(params.Address, params.Quantity)
+	case "ReadDiscreteInput":
+		data, err = x.conn.ReadDiscreteInput(params.Address)
+	case "ReadRegisters":
+		data, err = x.conn.ReadRegisters(params.Address, params.Quantity, params.RegType)
+	case "ReadRegister":
+		data, err = x.conn.ReadRegister(params.Address, params.RegType)
+	case "ReadUint32s":
+		data, err = x.conn.ReadUint32s(params.Address, params.Quantity, params.RegType)
+	case "ReadUint32":
+		data, err = x.conn.ReadUint32(params.Address, params.RegType)
+	case "ReadFloat32s":
+		data, err = x.conn.ReadFloat32s(params.Address, params.Quantity, params.RegType)
+	case "ReadFloat32":
+		data, err = x.conn.ReadFloat32(params.Address, params.RegType)
+	case "ReadUint64s":
+		data, err = x.conn.ReadUint64s(params.Address, params.Quantity, params.RegType)
+	case "ReadUint64":
+		data, err = x.conn.ReadUint64(params.Address, params.RegType)
+	case "ReadFloat64s":
+		data, err = x.conn.ReadFloat64s(params.Address, params.Quantity, params.RegType)
+	case "ReadFloat64":
+		data, err = x.conn.ReadFloat64(params.Address, params.RegType)
+	case "ReadBytes":
+		data, err = x.conn.ReadBytes(params.Address, params.Quantity, params.RegType)
+	case "ReadRawBytes":
+		data, err = x.conn.ReadRawBytes(params.Address, params.Quantity, params.RegType)
+	case "WriteCoil":
+		boolVal, err = byteToBool(params.Value)
+		err = x.conn.WriteCoil(params.Address, boolVal)
+	case "WriteCoils":
+		boolVals, err = byteToBools(params.Value)
+		err = x.conn.WriteCoils(params.Address, boolVals)
+	case "WriteRegister":
+		ui16, _ = byteToUint16(params.Value)
+		err = x.conn.WriteRegister(params.Address, ui16)
+	case "WriteRegisters":
+		ui16s, _ = byteToUint16s(params.Value)
+		err = x.conn.WriteRegisters(params.Address, ui16s)
+	case "WriteUint32":
+		ui32, _ = byteToUint32(params.Value)
+		err = x.conn.WriteUint32(params.Address, ui32)
+	case "WriteUint32s":
+		ui32s, _ = byteToUint32s(params.Value)
+		err = x.conn.WriteUint32s(params.Address, ui32s)
+	case "WriteFloat32":
+		f32, _ = byteToFloat32(params.Value)
+		err = x.conn.WriteFloat32(params.Address, f32)
+	case "WriteFloat32s":
+		f32s, _ = byteToFloat32s(params.Value)
+		err = x.conn.WriteFloat32s(params.Address, f32s)
+	case "WriteUint64":
+		ui64, _ = byteToUint64(params.Value)
+		err = x.conn.WriteUint64(params.Address, ui64)
+	case "WriteUint64s":
+		ui64s, _ = byteToUint64s(params.Value)
+		err = x.conn.WriteUint64s(params.Address, ui64s)
+	case "WriteFloat64":
+		f64, _ = byteToFloat64(params.Value)
+		err = x.conn.WriteFloat64(params.Address, f64)
+	case "WriteFloat64s":
+		f64s, _ = byteToFloat64s(params.Value)
+		err = x.conn.WriteFloat64s(params.Address, f64s)
+	case "WriteBytes":
+		err = x.conn.WriteBytes(params.Address, params.Value)
+	case "WriteRawBytes":
+		err = x.conn.WriteRawBytes(params.Address, params.Value)
+	default:
+		err = fmt.Errorf("unknown command：%s", x.Config.Cmd)
+	}
+	if err != nil {
+		ctx.TellFailure(msg, err)
+	} else {
+		result.Data = data
+		bytes, err := json.Marshal(result)
+		if err != nil {
+			ctx.TellFailure(msg, err)
+			return
+		}
+		msg.Data = str.ToString(bytes)
+		ctx.TellSuccess(msg)
+	}
+}
+
+// getParams 获取参数
+func (x *ModbusNode) getParams(ctx types.RuleContext, msg types.RuleMsg) (*Params, error) {
+	var (
+		err       error
+		tmp       uint64
+		address   uint16
+		quanitity uint16
+		val       string
+		value     []byte
+		regType   modbus.RegType = modbus.HOLDING_REGISTER
+		params                   = Params{}
+	)
+	evn := base.NodeUtils.GetEvnAndMetadata(ctx, msg)
+	// 获取address
+	if !x.addressTemplate.IsNotVar() {
+		tmp, err = strconv.ParseUint(x.addressTemplate.Execute(evn), 10, 16)
+		address = uint16(tmp)
+	} else if len(x.Config.Address) > 0 {
+		tmp, err = strconv.ParseUint(x.Config.Address, 10, 16)
+		address = uint16(tmp)
+	}
+	// 获取quantity
+	if !x.quanitityTemplate.IsNotVar() {
+		tmp, err = strconv.ParseUint(x.addressTemplate.Execute(evn), 10, 16)
+		quanitity = uint16(tmp)
+	} else if len(x.Config.Quantity) > 0 {
+		tmp, err = strconv.ParseUint(x.Config.Quantity, 10, 16)
+		quanitity = uint16(tmp)
+	}
+	// 获取regType
+	if !x.regTypeTemplate.IsNotVar() {
+		tmp, err = strconv.ParseUint(x.regTypeTemplate.Execute(evn), 10, 16)
+		regType = modbus.RegType(tmp)
+	} else if len(x.Config.RegType) > 0 {
+		tmp, err = strconv.ParseUint(x.Config.RegType, 10, 16)
+		regType = modbus.RegType(tmp)
+	}
+	// 获取value
+	if !x.valueTemplate.IsNotVar() {
+		val = x.valueTemplate.Execute(evn)
+		value = []byte(val)
+	} else if len(x.Config.Value) > 0 {
+		val = x.Config.Value
+		value = []byte(val)
+	}
+	if err != nil {
+		return nil, err
+	}
+	// 更新参数
+	params.Cmd = x.Config.Cmd
+	params.Address = address
+	params.Quantity = quanitity
+	params.Value = value
+	params.Val = val
+	params.RegType = regType
+	return &params, nil
+}
+
+// Destroy 销毁组件
+func (x *ModbusNode) Destroy() {
+	if x.conn != nil {
+		_ = x.conn.Close()
+		x.conn = nil
+	}
+}
+
+// Printf 打印日志
+func (x *ModbusNode) Printf(format string, v ...interface{}) {
+	if x.RuleConfig.Logger != nil {
+		x.RuleConfig.Logger.Printf(format, v...)
+	}
+}
+
+// 初始化连接
+func (x *ModbusNode) initClient() (*modbus.ModbusClient, error) {
+	if x.conn != nil {
+		return x.conn, nil
+	} else {
+		x.Locker.Lock()
+		defer x.Locker.Unlock()
+		if x.conn != nil {
+			return x.conn, nil
+		}
+		var err error
+		config := &modbus.ClientConfiguration{
+			URL:      x.Config.Server,
+			Speed:    x.Config.Speed,
+			DataBits: x.Config.DataBits,
+			StopBits: x.Config.StopBits,
+			Timeout:  time.Duration(x.Config.Timeout) * time.Second,
+			Parity:   x.Config.Parity,
+		}
+		// handle TLS options
+		if strings.HasPrefix(x.Config.Server, "tcp+tls://") {
+			clientKeyPair, err := tls.LoadX509KeyPair(x.Config.CertPath, x.Config.KeyPath)
+			if err != nil {
+				x.Printf("failed to load client tls key pair: %v\n", err)
+				return nil, err
+			}
+			config.TLSClientCert = &clientKeyPair
+
+			config.TLSRootCAs, err = modbus.LoadCertPool(x.Config.CaPath)
+			if err != nil {
+				x.Printf("failed to load tls CA/server certificate: %v\n", err)
+				return nil, err
+			}
+		}
+
+		x.conn, err = modbus.NewClient(config)
+		x.conn.SetEncoding(x.Config.Endianness, x.Config.WordOrder)
+		x.conn.SetUnitId(x.Config.UnitId)
+		if err != nil {
+			return nil, err
+		}
+		err = x.conn.Open()
+		return x.conn, err
+	}
+}
+
+func byteToBool(data []byte) (bool, error) {
+	var value bool
+	err := json.Unmarshal(data, &value)
+	return value, err
+}
+
+func byteToBools(data []byte) ([]bool, error) {
+	var value []bool
+	err := json.Unmarshal(data, &value)
+	return value, err
+}
+
+func byteToUint64(data []byte) (uint64, error) {
+	var value uint64
+	err := json.Unmarshal(data, &value)
+	return value, err
+}
+
+func byteToUint64s(data []byte) ([]uint64, error) {
+	var value []uint64
+	err := json.Unmarshal(data, &value)
+	return value, err
+}
+
+func byteToUint32(data []byte) (uint32, error) {
+	var value uint32
+	err := json.Unmarshal(data, &value)
+	return value, err
+}
+
+func byteToUint32s(data []byte) ([]uint32, error) {
+	var value []uint32
+	err := json.Unmarshal(data, &value)
+	return value, err
+}
+
+func byteToUint16(data []byte) (uint16, error) {
+	var value uint16
+	err := json.Unmarshal(data, &value)
+	return value, err
+}
+
+func byteToUint16s(data []byte) ([]uint16, error) {
+	var value []uint16
+	err := json.Unmarshal(data, &value)
+	return value, err
+}
+
+func byteToFloat32(data []byte) (float32, error) {
+	var value float32
+	err := json.Unmarshal(data, &value)
+	return value, err
+}
+
+func byteToFloat32s(data []byte) ([]float32, error) {
+	var value []float32
+	err := json.Unmarshal(data, &value)
+	return value, err
+}
+
+func byteToFloat64(data []byte) (float64, error) {
+	var value float64
+	err := json.Unmarshal(data, &value)
+	return value, err
+}
+
+func byteToFloat64s(data []byte) ([]float64, error) {
+	var value []float64
+	err := json.Unmarshal(data, &value)
+	return value, err
+}

--- a/external/modbus/modbus.go
+++ b/external/modbus/modbus.go
@@ -233,7 +233,7 @@ func (x *ModbusNode) OnMsg(ctx types.RuleContext, msg types.RuleMsg) {
 			data = readModbusValues(boolVals, params.Address, 1, x.Config.UnitId)
 		}
 	case "ReadCoil":
-		boolVal, err := x.conn.ReadCoil(params.Address)
+		boolVal, err = x.conn.ReadCoil(params.Address)
 		if err == nil {
 			boolVals = append(boolVals, boolVal)
 			data = readModbusValues(boolVals, params.Address, 1, x.Config.UnitId)
@@ -316,39 +316,75 @@ func (x *ModbusNode) OnMsg(ctx types.RuleContext, msg types.RuleMsg) {
 		}
 	case "WriteCoil":
 		boolVal, err = byteToBool(params.Value)
+		if err != nil {
+			x.Printf("convert value error:%s", err)
+		}
 		err = x.conn.WriteCoil(params.Address, boolVal)
 	case "WriteCoils":
 		boolVals, err = byteToBools(params.Value)
+		if err != nil {
+			x.Printf("convert value error:%s", err)
+		}
 		err = x.conn.WriteCoils(params.Address, boolVals)
 	case "WriteRegister":
-		ui16, _ = byteToUint16(params.Value)
+		ui16, err = byteToUint16(params.Value)
+		if err != nil {
+			x.Printf("convert value error:%s", err)
+		}
 		err = x.conn.WriteRegister(params.Address, ui16)
 	case "WriteRegisters":
-		ui16s, _ = byteToUint16s(params.Value)
+		ui16s, err = byteToUint16s(params.Value)
+		if err != nil {
+			x.Printf("convert value error:%s", err)
+		}
 		err = x.conn.WriteRegisters(params.Address, ui16s)
 	case "WriteUint32":
-		ui32, _ = byteToUint32(params.Value)
+		ui32, err = byteToUint32(params.Value)
+		if err != nil {
+			x.Printf("convert value error:%s", err)
+		}
 		err = x.conn.WriteUint32(params.Address, ui32)
 	case "WriteUint32s":
-		ui32s, _ = byteToUint32s(params.Value)
+		ui32s, err = byteToUint32s(params.Value)
+		if err != nil {
+			x.Printf("convert value error:%s", err)
+		}
 		err = x.conn.WriteUint32s(params.Address, ui32s)
 	case "WriteFloat32":
-		f32, _ = byteToFloat32(params.Value)
+		f32, err = byteToFloat32(params.Value)
+		if err != nil {
+			x.Printf("convert value error:%s", err)
+		}
 		err = x.conn.WriteFloat32(params.Address, f32)
 	case "WriteFloat32s":
-		f32s, _ = byteToFloat32s(params.Value)
+		f32s, err = byteToFloat32s(params.Value)
+		if err != nil {
+			x.Printf("convert value error:%s", err)
+		}
 		err = x.conn.WriteFloat32s(params.Address, f32s)
 	case "WriteUint64":
-		ui64, _ = byteToUint64(params.Value)
+		ui64, err = byteToUint64(params.Value)
+		if err != nil {
+			x.Printf("convert value error:%s", err)
+		}
 		err = x.conn.WriteUint64(params.Address, ui64)
 	case "WriteUint64s":
-		ui64s, _ = byteToUint64s(params.Value)
+		ui64s, err = byteToUint64s(params.Value)
+		if err != nil {
+			x.Printf("convert value error:%s", err)
+		}
 		err = x.conn.WriteUint64s(params.Address, ui64s)
 	case "WriteFloat64":
-		f64, _ = byteToFloat64(params.Value)
+		f64, err = byteToFloat64(params.Value)
+		if err != nil {
+			x.Printf("convert value error:%s", err)
+		}
 		err = x.conn.WriteFloat64(params.Address, f64)
 	case "WriteFloat64s":
-		f64s, _ = byteToFloat64s(params.Value)
+		f64s, err = byteToFloat64s(params.Value)
+		if err != nil {
+			x.Printf("convert value error:%s", err)
+		}
 		err = x.conn.WriteFloat64s(params.Address, f64s)
 	case "WriteBytes":
 		err = x.conn.WriteBytes(params.Address, params.Value)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gopcua/opcua v0.6.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rulego/rulego v0.27.0
+	github.com/simonvetter/modbus v1.6.3
 )
 
 require (
@@ -16,6 +17,7 @@ require (
 	github.com/expr-lang/expr v1.16.9 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
+	github.com/goburrow/serial v0.1.0 // indirect
 	github.com/gofrs/uuid/v5 v5.0.0 // indirect
 	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect


### PR DESCRIPTION

`x/modbus`组件：版本 v0.28.0+，用于执行 Modbus 协议的读取或写入操作。

> 需要额外引入扩展库： [rulego-components-iot](https://github.com/rulego/rulego-components-iot)

## 配置

| 字段          | 类型     | 说明                                                       | 默认值       |
|-------------|--------|----------------------------------------------------------|-----------|
| server      | string | Modbus服务器地址（格式：`<mode>://<host:port>` or `<mode>://<serial device>`） | tcp://127.0.0.1:502        |
| unitId      | uint8  | 单元编号（从机编号）                                            | 1         |
| timeout     | int64  | 请求超时时间，单位为秒                                             | 5         |
| endianness  | uint   | 寄存器的字节序，可选值：`BIG_ENDIAN`（大端序:1）、`LITTLE_ENDIAN`（小端序:2） | 1         |
| wordOrder   | uint   | 32位寄存器的字序，可选值：`HIGH_WORD_FIRST`（高字在前:1）、`LOW_WORD_FIRST`（低字在前:2） | 1         |
| cmd         | string | Modbus命令名称，支持的命令包括：`ReadCoils`, `ReadDiscreteInputs`, `ReadRegisters`, `WriteCoil`, `WriteRegisters` 等 | ReadCoils         |
| address     | string | 寄存器地址，允许使用`${}`占位符变量                                  | 无         |
| quantity    | string | 寄存器数量，允许使用`${}`占位符变量                                  | 无         |
| value       | string | 寄存器值，允许使用`${}`占位符变量                                    | 无         |
| regType     | uint   | 寄存器类型，可选值：`HOLDING_REGISTER`（保持寄存器）、`INPUT_REGISTER`（输入寄存器） | 无         |
| parity      | uint   | 校验位（仅RTU模式），可选值：`PARITY_NONE`（无校验:0）、`PARITY_EVEN`（偶校验:1）、`PARITY_ODD`（奇校验:2） | 0         |
| speed       | uint   | 串行波特率（仅RTU模式）                                             | 19200        |
| dataBits    | uint   | 数据位数（仅RTU模式）                                               | 8        |
| stopBits    | uint   | 停止位数（仅RTU模式）                                               | 2         |
| certPath    | string | 证书路径（TLS/SSL连接时需要提供）                                     | 无         |
| keyPath     | string | 私钥路径（TLS/SSL连接时需要提供）                                     | 无         |
| caPath      | string | CA证书路径（TLS/SSL连接时需要提供）                                   | 无         |


## 命令说明

| 命令名 | 命令说明 | 参数描述 |
|--------|----------|----------|
| ReadCoils | 读取线圈状态 | `address`：线圈起始地址<br>`quantity`：读取数量 |
| ReadCoil | 读取单个线圈状态 | `address`：线圈地址 |
| ReadDiscreteInputs | 读取离散输入状态 | `address`：离散输入起始地址<br>`quantity`：读取数量 |
| ReadDiscreteInput | 读取单个离散输入状态 | `address`：离散输入地址 |
| ReadRegisters | 读取寄存器 | `address`：寄存器起始地址<br>`quantity`：读取数量<br>`regType`：寄存器类型（如保持寄存器或输入寄存器） |
| ReadRegister | 读取单个寄存器 | `address`：寄存器地址<br>`regType`：寄存器类型 |
| ReadUint32s | 读取无符号32位整数 | `address`：寄存器起始地址<br>`quantity`：读取数量<br>`regType`：寄存器类型 |
| ReadUint32 | 读取单个无符号32位整数 | `address`：寄存器地址<br>`regType`：寄存器类型 |
| ReadFloat32s | 读取浮点数32位 | `address`：寄存器起始地址<br>`quantity`：读取数量<br>`regType`：寄存器类型 |
| ReadFloat32 | 读取单个浮点数32位 | `address`：寄存器地址<br>`regType`：寄存器类型 |
| ReadUint64s | 读取无符号64位整数 | `address`：寄存器起始地址<br>`quantity`：读取数量<br>`regType`：寄存器类型 |
| ReadUint64 | 读取单个无符号64位整数 | `address`：寄存器地址<br>`regType`：寄存器类型 |
| ReadFloat64s | 读取浮点数64位 | `address`：寄存器起始地址<br>`quantity`：读取数量<br>`regType`：寄存器类型 |
| ReadFloat64 | 读取单个浮点数64位 | `address`：寄存器地址<br>`regType`：寄存器类型 |
| ReadBytes | 读取字节数据 | `address`：寄存器起始地址<br>`quantity`：读取数量<br>`regType`：寄存器类型 |
| ReadRawBytes | 读取原始字节数据 | `address`：寄存器起始地址<br>`quantity`：读取数量<br>`regType`：寄存器类型 |
| WriteCoil | 写入单个线圈状态 | `address`：线圈地址<br>`value`：写入值（布尔值） |
| WriteCoils | 写入多个线圈状态 | `address`：线圈起始地址<br>`value`：写入值（布尔数组） |
| WriteRegister | 写入单个寄存器 | `address`：寄存器地址<br>`value`：写入值（16位整数） |
| WriteRegisters | 写入多个寄存器 | `address`：寄存器起始地址<br>`value`：写入值（16位整数数组） |
| WriteUint32 | 写入单个无符号32位整数 | `address`：寄存器地址<br>`value`：写入值（32位整数） |
| WriteUint32s | 写入多个无符号32位整数 | `address`：寄存器起始地址<br>`value`：写入值（32位整数数组） |
| WriteFloat32 | 写入单个浮点数32位 | `address`：寄存器地址<br>`value`：写入值（浮点数） |
| WriteFloat32s | 写入多个浮点数32位 | `address`：寄存器起始地址<br>`value`：写入值（浮点数数组） |
| WriteUint64 | 写入单个无符号64位整数 | `address`：寄存器地址<br>`value`：写入值（64位整数） |
| WriteUint64s | 写入多个无符号64位整数 | `address`：寄存器起始地址<br>`value`：写入值（64位整数数组） |
| WriteFloat64 | 写入单个浮点数64位 | `address`：寄存器地址<br>`value`：写入值（浮点数） |
| WriteFloat64s | 写入多个浮点数64位 | `address`：寄存器起始地址<br>`value`：写入值（浮点数数组） |
| WriteBytes | 写入字节数据 | `address`：寄存器起始地址<br>`value`：写入值（字节数组） |
| WriteRawBytes | 写入原始字节数据 | `address`：寄存器起始地址<br>`value`：写入值（字节数组） |

## Relation Type

- ***Success:*** 执行成功，把消息发送到`Success`链。
- ***Failure:*** 执行失败，把消息发送到`Failure`链。

## 执行结果

不改变消息负荷值。